### PR TITLE
Fix examplecat.com link

### DIFF
--- a/problem-dns-update.twee
+++ b/problem-dns-update.twee
@@ -35,11 +35,11 @@ Click "Start" to get started.
 :: Landing
 
 <p>
-You're moving your website (https://examplecat.com) to a new web host -- you
-want to switch from using a static site hosting tool to your own server, which
-you've set up with nginx. You vaguely remember that you were using AWS to
-manage your DNS, so you go to the AWS web console, and update the IP address
-from `157.245.84.7` to `12.13.14.15`.
+You're moving your website (<a href="https://examplecat.com">examplecat.com</a>)
+to a new web host -- you want to switch from using a static site hosting tool to
+your own server, which you've set up with nginx. You vaguely remember that you
+were using AWS to manage your DNS, so you go to the AWS web console, and update
+the IP address from `157.245.84.7` to `12.13.14.15`.
 </p>
 
 <p>


### PR DESCRIPTION
https://mysteries.wizardzines.com/problem-dns-update.html has a link to examplecat.com. However, Twine (tweego? markdown processor? something in the stack!) interprets the closing paren as part of the link.
![20210506_13h27m31s_grim](https://user-images.githubusercontent.com/8261698/117347775-11e8bb80-ae6f-11eb-970d-3a3bd2261c31.png)

Explicitly specifying the link as an `<a>` tag should help. Unfortunately, simply adding the explicit tags doesn't work, since the implicit link still gets parsed from _inside_ of the explicit link! This winds up being a whole mess:
```diff
diff --git a/problem-dns-update.twee b/problem-dns-update.twee
index f38c68d..9b81424 100644
--- a/problem-dns-update.twee
+++ b/problem-dns-update.twee
@@ -35,7 +35,7 @@ Click "Start" to get started.
 :: Landing
 
 <p>
-You're moving your website (https://examplecat.com) to a new web host -- you
+You're moving your website (<a href="https://examplecat.com">https://examplecat.com</a>) to a new web host -- you
 want to switch from using a static site hosting tool to your own server, which
 you've set up with nginx. You vaguely remember that you were using AWS to
 manage your DNS, so you go to the AWS web console, and update the IP address
 ```
![20210506_13h25m29s_grim](https://user-images.githubusercontent.com/8261698/117347778-11e8bb80-ae6f-11eb-9601-36ac4b785eb9.png)


So I wound up removing the `https://` and that seems to do the trick:
![20210506_13h28m01s_grim](https://user-images.githubusercontent.com/8261698/117347774-10b78e80-ae6f-11eb-912b-22238e96e830.png)
